### PR TITLE
(Console) Bug fix for membuf & Uart

### DIFF
--- a/src/driver/console/console_membuf/console_membuf.c
+++ b/src/driver/console/console_membuf/console_membuf.c
@@ -28,7 +28,7 @@ status_t membuf_setup()
 status_t membuf_writeb(const char c)
 {
 	static size_t pointer = 0;
-	if(c =='\b' && pointer)
+	if(c == '\b' && pointer)
 	{
 		pointer --;
 		return success;

--- a/src/driver/console/console_membuf/console_membuf.c
+++ b/src/driver/console/console_membuf/console_membuf.c
@@ -28,6 +28,11 @@ status_t membuf_setup()
 status_t membuf_writeb(const char c)
 {
 	static size_t pointer = 0;
+	if(c =='\b' && pointer)
+	{
+		pointer --;
+		return success;
+	}
 	if(pointer == MEMBUF_SIZE)	// Roll over after buffer is full
 		pointer = 0;
 	membuf[pointer++] = c;

--- a/src/platform/mega_avr/common/hal/uart/uart.c
+++ b/src/platform/mega_avr/common/hal/uart/uart.c
@@ -68,9 +68,7 @@ status_t uart_setup(uart_port_t *port, direction_t d, parity_t p)
 	// Configure frame
 	// Defaults to
 	// Async UART, 1 stop bit, Rising edge clk
-	MMIO8(port->baddr + UCSRC_OFFSET) = 0;
-	MMIO8(port->baddr + UCSRC_OFFSET) |= (p << UPM0);	// Set Parity
-	MMIO8(port->baddr + UCSRC_OFFSET) |= (3 << UCSZ0);	// 8bit frame
+	MMIO8(port->baddr + UCSRC_OFFSET) = (p << UPM0) | (3 << UCSZ0); // Set Parity & 8 bit frame
 	return ret;
 }
 


### PR DESCRIPTION
* (Membuf) "\b" causes memory usage bypassing actual job done by "\b".
* (UART HAL) redundant line of code & unnecessary load store operations.

