### PR TITLE
<Driver> Updated all drivers to use heap memory

### DIFF
--- a/src/arch/avr/8/common_5x_6/terravisor/arch.c
+++ b/src/arch/avr/8/common_5x_6/terravisor/arch.c
@@ -96,6 +96,8 @@ void _NORETURN arch_panic_handler_callback()
 {
 	context_frame_t *frame;
 	frame = get_context_frame();
+	if(!frame)
+		goto panic;
 	syslog_stdout_enable();
 	sysdbg("r0=%p\tr1=%p\tr2=%p\tr3=%p\tr4=%p\tr5=%p\n",
 		frame->r0, frame->r1, frame->r2, frame->r3, frame->r4, frame->r5);
@@ -112,5 +114,6 @@ void _NORETURN arch_panic_handler_callback()
 #if DEBUG==0
 	syslog(info, "SP=%p\tSREG = %p\n", frame, frame->sreg);
 #endif
+panic:
 	while(1) arch_wfi();
 }

--- a/src/arch/avr/8/common_5x_6/terravisor/interrupt_handler.c
+++ b/src/arch/avr/8/common_5x_6/terravisor/interrupt_handler.c
@@ -106,12 +106,9 @@ void interrupt_handler(unsigned char id, context_frame_t *frame)
 }
 
 
-/* Fixed memory block of 33 bytes on bss */
-context_frame_t snapshot_frame;
-
 context_frame_t *get_context_frame()
 {
 	if(local_frame)
 		return local_frame;
-	return &snapshot_frame;
+	return NULL;
 }

--- a/src/driver/console/con_serial_mega_avr/console_serial.c
+++ b/src/driver/console/con_serial_mega_avr/console_serial.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <status.h>
 #include <syslog.h>
+#include <stdlib.h>
 #include <lock/spinlock.h>
 #include <resource.h>
 #include <machine_call.h>
@@ -22,7 +23,7 @@
 #include <hal/uart.h>
 #include <driver/console.h>
 
-static uart_port_t console_port;
+static uart_port_t *console_port;
 
 static void console_serial_write_irq_handler(void);
 static void console_serial_read_irq_handler(void);
@@ -48,24 +49,27 @@ static status_t console_serial_setup()
 		return mres.status;
 	}
 	dp = (module_t *)mres.p;
-	console_port.port_id = dp->id;
-	console_port.clk_id = dp->clk_id;
-	console_port.baddr = dp->baddr;
-	console_port.stride = dp->stride;
-	console_port.baud = dp->clk;
-	console_port.tx_irq = &dp->interrupt[1];
-	console_port.tx_handler = console_serial_write_irq_handler;
-	console_port.rx_irq = &dp->interrupt[0];
-	console_port.rx_handler = console_serial_read_irq_handler;
+	console_port = (uart_port_t *)malloc(sizeof(uart_port_t));
+	if(!console_port)
+		return error_memory_low;
+	console_port->port_id = dp->id;
+	console_port->clk_id = dp->clk_id;
+	console_port->baddr = dp->baddr;
+	console_port->stride = dp->stride;
+	console_port->baud = dp->clk;
+	console_port->tx_irq = &dp->interrupt[1];
+	console_port->tx_handler = console_serial_write_irq_handler;
+	console_port->rx_irq = &dp->interrupt[0];
+	console_port->rx_handler = console_serial_read_irq_handler;
 
-	sysdbg2("UART engine @ %p\n", console_port.baddr);
-	sysdbg2("UART baud @ %lubps\n", console_port.baud);
+	sysdbg2("UART engine @ %p\n", console_port->baddr);
+	sysdbg2("UART baud @ %lubps\n", console_port->baud);
 	sysdbg2("UART irqs - %u & %u\n", dp->interrupt[1].id, dp->interrupt[0].id);
 	/*
 	 * If memory mapping is applicable,
 	 * put it in mmu supported guide.
 	 */
-	return uart_setup(&console_port, trx, no_parity); //
+	return uart_setup(console_port, trx, no_parity); //
 }
 
 static int_wait_t con_write_wait;
@@ -79,7 +83,7 @@ status_t console_serial_write(const char c)
 {
 	status_t ret;
 	ret = wait_lock(&con_write_wait);
-	ret |= uart_tx(&console_port, c);
+	ret |= uart_tx(console_port, c);
 	ret |= wait_till_irq(&con_write_wait);
 	return ret;
 }
@@ -90,7 +94,7 @@ static char con_char;
 static void console_serial_read_irq_handler()
 {
 	wait_release_on_irq(&con_read_wait);
-	uart_rx(&console_port, &con_char);
+	uart_rx(console_port, &con_char);
 }
 
 static status_t console_serial_read(char *c)
@@ -102,24 +106,19 @@ static status_t console_serial_read(char *c)
 	return ret;
 }
 
-static status_t console_serial_flush()
-{
-	return success;
-}
-
-static console_t console_serial_driver =
-{
-	.write = &console_serial_write,
-	.read = &console_serial_read,
-	.flush = &console_serial_flush
-};
+static console_t *console_serial_driver;
 
 status_t console_serial_driver_setup()
 {
 	status_t ret;
 	driver_exit("earlycon");
+	console_serial_driver = (console_t *)malloc(sizeof(console_t));
+	if(!console_serial_driver)
+		return error_memory_low;
+	console_serial_driver->write = &console_serial_write;
+	console_serial_driver->read = &console_serial_read;
 	ret = console_serial_setup();
-	ret |= console_attach_device(ret, &console_serial_driver);
+	ret |= console_attach_device(ret, console_serial_driver);
 	return ret;
 }
 
@@ -127,8 +126,10 @@ status_t console_serial_driver_exit()
 {
 	status_t ret;
 	ret = console_release_device();
-	ret |= uart_shutdown(&console_port);
-	driver_setup("earlycon");
+	ret |= uart_shutdown(console_port);
+	free(console_serial_driver);
+	free(console_port);
+	ret |= driver_setup("earlycon");
 	return ret;
 }
 

--- a/src/driver/driver.c
+++ b/src/driver/driver.c
@@ -202,7 +202,7 @@ status_t driver_register(device_t *dev _UNUSED)
 
 	ret = dev->driver_setup();
 	(ret == success) ? syslog(pass, "Started %s\n", dev->name) :
-		syslog(fail, "Couldn't start %s\n", dev->name);
+		syslog(fail, "Couldn't start %s (Err: -%p)\n", dev->name, -ret);
 exit:
 	return ret;
 }

--- a/src/driver/interrupt/plic/plic.c
+++ b/src/driver/interrupt/plic/plic.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <status.h>
 #include <syslog.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <assert.h>
 #include <arch.h>
@@ -28,7 +29,7 @@
 
 #include "plic_private.h"
 
-static plic_port_t port;
+static plic_port_t *port;
 
 static status_t plic_setup()
 {
@@ -40,38 +41,41 @@ static status_t plic_setup()
 	if(mres.status != success)
 		return mres.status;
 	dp = (module_t *)mres.p;
-	port.baddr = dp->baddr;
-	port.stride = dp->stride;
-	port.port_id = plic;
-	port.irq = &dp->interrupt[0];
-	syslog(info, "PLIC @ 0x%x found.\n", (unsigned int)port.baddr);
+	port = (plic_port_t *)malloc(sizeof(plic_port_t));
+	if(!port)
+		return error_memory_low;
+	port->baddr = dp->baddr;
+	port->stride = dp->stride;
+	port->port_id = plic;
+	port->irq = &dp->interrupt[0];
+	syslog(info, "PLIC @ 0x%x found.\n", (unsigned int)port->baddr);
 	return success;
 }
 
 static uint32_t plic_get_priority(uint32_t irq_id)
 {
-	assert(port.baddr);
-	return MMIO32(port.baddr + PLIC_IPRIORITY_OFFSET(irq_id));
+	assert(port->baddr);
+	return MMIO32(port->baddr + PLIC_IPRIORITY_OFFSET(irq_id));
 }
 
 static status_t plic_set_priority(uint32_t irq_id, uint32_t priority)
 {
-	assert(port.baddr);
-	MMIO32(port.baddr + PLIC_IPRIORITY_OFFSET(irq_id)) = priority;
+	assert(port->baddr);
+	MMIO32(port->baddr + PLIC_IPRIORITY_OFFSET(irq_id)) = priority;
 	arch_dmb();
 	return success;
 }
 
 static uint32_t plic_get_threshold(uint32_t core_id)
 {
-	assert(port.baddr);
-	return MMIO32(port.baddr + PLIC_ITHRESHOLD_OFFSET(core_id));
+	assert(port->baddr);
+	return MMIO32(port->baddr + PLIC_ITHRESHOLD_OFFSET(core_id));
 }
 
 static status_t plic_set_threshold(uint32_t core_id, uint32_t threshold)
 {
-	assert(port.baddr);
-	MMIO32(port.baddr + PLIC_ITHRESHOLD_OFFSET(core_id)) = threshold;
+	assert(port->baddr);
+	MMIO32(port->baddr + PLIC_ITHRESHOLD_OFFSET(core_id)) = threshold;
 	arch_dmb();
 	return success;
 }
@@ -80,9 +84,9 @@ static uint32_t plic_get_interrupt()
 {
 	unsigned int irq;
 	uint32_t core_id;
-	assert(port.baddr);
+	assert(port->baddr);
 	core_id = arch_core_index();
-	irq = MMIO32(port.baddr + PLIC_ICLAIM_OFFSET(core_id));
+	irq = MMIO32(port->baddr + PLIC_ICLAIM_OFFSET(core_id));
 	arch_dmb();
 	return irq;
 }
@@ -91,10 +95,10 @@ static uint32_t plic_get_interrupt()
 static void plic_clr_interrupt(uint32_t irq_id)
 {
 	uint32_t core_id;
-	assert(port.baddr);
+	assert(port->baddr);
 	core_id = arch_core_index();
 	sysdbg3("Clearing IRQ#%u on Core-%u\n", irq_id, core_id);
-	MMIO32(port.baddr + PLIC_ICLAIM_OFFSET(core_id)) = irq_id;
+	MMIO32(port->baddr + PLIC_ICLAIM_OFFSET(core_id)) = irq_id;
 	arch_dmb();
 	return;
 }
@@ -102,11 +106,11 @@ static void plic_clr_interrupt(uint32_t irq_id)
 static status_t plic_int_en(uint32_t irq_id)
 {
 	uint32_t core_id, irq_shift;
-	assert(port.baddr);
+	assert(port->baddr);
 	core_id = arch_core_index();
 	sysdbg3("Enabling IRQ#%u on Core-%u\n", irq_id, core_id);
 	irq_shift = irq_id % 32;
-	MMIO32(port.baddr + PLIC_IENABLE_OFFSET(core_id, irq_id)) |= (1 << irq_shift);
+	MMIO32(port->baddr + PLIC_IENABLE_OFFSET(core_id, irq_id)) |= (1 << irq_shift);
 	arch_dmb();
 	return success;
 }
@@ -114,11 +118,11 @@ static status_t plic_int_en(uint32_t irq_id)
 static status_t plic_int_dis(uint32_t irq_id)
 {
 	uint32_t core_id, irq_shift;
-	assert(port.baddr);
+	assert(port->baddr);
 	core_id = arch_core_index();
 	sysdbg3("Disabling IRQ#%u on Core-%u\n", irq_id, core_id);
 	irq_shift = irq_id % 32;
-	MMIO32(port.baddr + PLIC_IENABLE_OFFSET(core_id, irq_id)) &= ~(1 << irq_shift);
+	MMIO32(port->baddr + PLIC_IENABLE_OFFSET(core_id, irq_id)) &= ~(1 << irq_shift);
 	arch_dmb();
 	return success;
 }
@@ -134,8 +138,8 @@ static void plic_irqhandler()
 static bool plic_get_pending(uint32_t irq_id)
 {
 	uint32_t pending;
-	assert(port.baddr);
-	pending = MMIO32(port.baddr + PLIC_IPENDING_OFFSET(irq_id));
+	assert(port->baddr);
+	pending = MMIO32(port->baddr + PLIC_IPENDING_OFFSET(irq_id));
 	return (pending & (1 << (irq_id % 32))) ? true : false;
 }
 
@@ -178,9 +182,9 @@ static status_t plic_driver_setup_pcpu()
 {
 	status_t ret;
 	unsigned int irq;
-	sysdbg3("Linking local IRQ#%u on Core-%u\n", port.irq->id, arch_core_index());
+	sysdbg3("Linking local IRQ#%u on Core-%u\n", port->irq->id, arch_core_index());
 	plic_set_threshold(arch_core_index(), 0);
-	ret = link_interrupt(port.irq->module, port.irq->id, &plic_irqhandler);
+	ret = link_interrupt(port->irq->module, port->irq->id, &plic_irqhandler);
 	do
 	{
 		irq = plic_get_interrupt();
@@ -193,13 +197,14 @@ static status_t plic_driver_setup_pcpu()
 
 static status_t plic_driver_exit()
 {
+	free(port);
 	return ic_release_device();
 }
 
 static status_t plic_driver_exit_pcpu()
 {
 	arch_di_mei();
-	return unlink_interrupt(port.irq->module, port.irq->id);
+	return unlink_interrupt(port->irq->module, port->irq->id);
 }
 
 INCLUDE_DRIVER(riscv_plic, plic_driver_setup, plic_driver_exit, 0, 0, 0);

--- a/src/platform/mega_avr/atmega2560/include/plat_mem.h
+++ b/src/platform/mega_avr/atmega2560/include/plat_mem.h
@@ -25,4 +25,4 @@
 
 #define STACK_SIZE	1024
 
-#define HEAP_SIZE	128
+#define HEAP_SIZE	1024

--- a/src/platform/mega_avr/atmega328p/include/plat_mem.h
+++ b/src/platform/mega_avr/atmega328p/include/plat_mem.h
@@ -25,5 +25,5 @@
 
 #define STACK_SIZE	0x0200
 
-#define HEAP_SIZE	128
+#define HEAP_SIZE	256
 #define HEAP_ALIGN	1

--- a/src/platform/mega_avr/common/sections.ld.sx
+++ b/src/platform/mega_avr/common/sections.ld.sx
@@ -54,7 +54,7 @@ SECTIONS
 
 	.heap :
 	{
-		. = ALIGN(8);
+		. = ALIGN(HEAP_ALIGN);
 		*(.heap)
 		KEEP(*(.heap))
 		. = . + HEAP_SIZE;

--- a/src/platform/sifive/common_fe310/sections.ld.sx
+++ b/src/platform/sifive/common_fe310/sections.ld.sx
@@ -115,7 +115,7 @@ SECTIONS
 		. = . + STACK_SIZE;
 	} > vma_dmem
 
-	.heap : ALIGN(8)
+	.heap : ALIGN(HEAP_ALIGN)
 	{
 		*(.heap)
 		KEEP(*(.heap))

--- a/src/platform/sifive/fe310g002-bl/include/plat_mem.h
+++ b/src/platform/sifive/fe310g002-bl/include/plat_mem.h
@@ -30,3 +30,4 @@
 #define STACK_SIZE_PCPU	0xc00
 
 #define HEAP_SIZE	512
+#define HEAP_ALIGN	4

--- a/src/platform/sifive/fe310g002/include/plat_mem.h
+++ b/src/platform/sifive/fe310g002/include/plat_mem.h
@@ -29,5 +29,5 @@
 #define STACK_SIZE	0xc00
 #define STACK_SIZE_PCPU	0xc00
 
-#define HEAP_SIZE	512
+#define HEAP_SIZE	4K
 #define HEAP_ALIGN	4


### PR DESCRIPTION
- Updated all driver programs to use heap memory instead of
  global memory space
- Removed redundant variables from avr arch code
- Updated driver engine to print error info
- Increased heap sized for mega_avr and sifive platforms

Issue: #147 