### PR TITLE
<libc> strcpy is now a macro which uses strlcpy

### DIFF
--- a/src/lib/libc/include/string.h
+++ b/src/lib/libc/include/string.h
@@ -129,4 +129,4 @@ char *strchr_rev(const char *i, int r);
  * i = destination address
  * j = source address
  */
-size_t strcpy(char *i, const char *j);
+#define strcpy(i, j)	strlcpy(i, j, strlen(j));

--- a/src/lib/libc/string.c
+++ b/src/lib/libc/string.c
@@ -205,7 +205,3 @@ char *strchr_rev(const char *i, int r)
 	return ret;
 }
 
-size_t strcpy(char *i, const char *j)
-{
-	return strlcpy(i, j, strlen(j));
-}


### PR DESCRIPTION
- strcpy function has risks buffer overflow, it will now be using strlcpy and strlen internally.